### PR TITLE
Bug/issue6

### DIFF
--- a/server.py
+++ b/server.py
@@ -57,16 +57,20 @@ def purchasePlaces():
     competition = [c for c in competitions if c['name'] == request.form['competition']][0]
     club = [c for c in clubs if c['name'] == request.form['club']][0]
     placesRequired = int(request.form['places'])
+    # check if that's the first book, and update session
     if competition['name'] in session:
         places = {competition['name']: session[competition['name']] + placesRequired}
     else:
         places = {competition['name']: placesRequired}
     points = int(club['points'])
+    # prevent to book more than 12 places
     if placesRequired <= 12:
         if places[competition['name']] <= 12:
+            # prevent to book more than available points
             if placesRequired <= points:
                 competition['numberOfPlaces'] = int(competition['numberOfPlaces']) - placesRequired
                 club['points'] = int(club['points']) - placesRequired
+                # set the session if that's the first book for this competition
                 if not competition['name'] in session:
                     session[competition['name']] = placesRequired
                 flash(f"Great ! {placesRequired} places booked for {competition['name']}")
@@ -86,5 +90,3 @@ def purchasePlaces():
 def logout():
     return redirect(url_for('index'))
 
-if (__name__ == "__main__"):
-    app.run(debug=True)

--- a/server.py
+++ b/server.py
@@ -65,6 +65,7 @@ def purchasePlaces():
         if places[competition['name']] <= 12:
             if placesRequired <= points:
                 competition['numberOfPlaces'] = int(competition['numberOfPlaces']) - placesRequired
+                club['points'] = int(club['points']) - placesRequired
                 print(club['points'])
                 if not competition['name'] in session:
                     session[competition['name']] = placesRequired

--- a/tests/test_purchase.py
+++ b/tests/test_purchase.py
@@ -4,38 +4,43 @@ from flask import session
 
 class TestPoints:
     
-    def test_should_nok_when_too_much_points(self, client, connect, club1):
+    def test_should_nok_when_too_much_points(self, client, connect, club2):
         points = int(connect.span.text)
-        club1.update({"places": points+1})
-        response = client.post('/purchasePlaces', data=club1)
+        club2.update({"places": points+1})
+        response = client.post('/purchasePlaces', data=club2)
         soup = BeautifulSoup(response.data, "html.parser")
         assert "You don't have enough points" == soup.li.text
 
-    def test_should_ok_when_enough_points(self, client, connect, club1):
+    def test_should_ok_when_enough_points(self, client, connect, club2):
         points = int(connect.span.text)
-        club1.update({"places": points-1})
-        response = client.post('/purchasePlaces', data=club1)
+        # One remaining point after that :
+        club2.update({"places": points-1})
+        response = client.post('/purchasePlaces', data=club2)
         soup = BeautifulSoup(response.data, "html.parser")
-        assert f"Great ! "+str(points-1)+" places booked for "+club1['competition'] == soup.li.text
+        assert f"Great ! "+str(points-1)+" places booked for "+club2['competition'] == soup.li.text
+
+    def test_book_more_than_one_should_be_refused(self, client, connect, club2):
+        points = int(connect.span.text)
+        assert int(points) == 1 
 
 
 class TestPlaces:
 
-    def test_should_refuse_more_12_once(self, client, club1):
-        club1.update({"places": 13})
-        response = client.post('/purchasePlaces', data=club1)
+    def test_should_refuse_more_12_once(self, client, club2):
+        club2.update({"places": 13})
+        response = client.post('/purchasePlaces', data=club2)
         soup = BeautifulSoup(response.data, "html.parser")
         assert "You can't book more than 12 places" == soup.li.text
 
-    def test_should_refuse_more_12_total(self, client, club1):
-        club1.update({"places": 2})
-        response = client.post('/purchasePlaces', data=club1)
+    def test_should_refuse_more_12_total(self, client, club2):
+        club2.update({"places": 1})
+        response = client.post('/purchasePlaces', data=club2)
         soup = BeautifulSoup(response.data, "html.parser")
-        assert "Great ! 2 places booked for "+club1['competition'] == soup.li.text 
-        club1.update({"places": 12})
-        response = client.post('/purchasePlaces', data=club1)
+        assert "Great ! 1 places booked for "+club2['competition'] == soup.li.text 
+        club2.update({"places": 12})
+        response = client.post('/purchasePlaces', data=club2)
         soup = BeautifulSoup(response.data, "html.parser")
-        assert "You already booked 12 places for "+club1['competition'] == soup.li.text
+        assert "You already booked 12 places for "+club2['competition'] == soup.li.text
 
         
 class TestDate:

--- a/tests/test_purchase.py
+++ b/tests/test_purchase.py
@@ -3,9 +3,10 @@ from flask import session
 
 
 class TestPoints:
-   '''
-   testing both case, book with and without enough points
-   '''
+    '''
+    testing both case, book with and without enough points
+    '''
+
     def test_should_nok_when_too_much_points(self, client, connect, club2):
         '''
         test booking an amount of places greater than the available points

--- a/tests/test_purchase.py
+++ b/tests/test_purchase.py
@@ -3,8 +3,13 @@ from flask import session
 
 
 class TestPoints:
-    
+   '''
+   testing both case, book with and without enough points
+   '''
     def test_should_nok_when_too_much_points(self, client, connect, club2):
+        '''
+        test booking an amount of places greater than the available points
+        '''
         points = int(connect.span.text)
         club2.update({"places": points+1})
         response = client.post('/purchasePlaces', data=club2)
@@ -12,6 +17,9 @@ class TestPoints:
         assert "You don't have enough points" == soup.li.text
 
     def test_should_ok_when_enough_points(self, client, connect, club2):
+        '''
+        test booking with enough points
+        '''
         points = int(connect.span.text)
         # One remaining point after that :
         club2.update({"places": points-1})
@@ -19,20 +27,25 @@ class TestPoints:
         soup = BeautifulSoup(response.data, "html.parser")
         assert f"Great ! "+str(points-1)+" places booked for "+club2['competition'] == soup.li.text
 
-    def test_book_more_than_one_should_be_refused(self, client, connect, club2):
-        points = int(connect.span.text)
-        assert int(points) == 1 
-
 
 class TestPlaces:
+    '''
+    test the booking limit of 12 places
+    '''
 
     def test_should_refuse_more_12_once(self, client, club2):
+        '''
+        test to book more than 12 places in one shot
+        '''
         club2.update({"places": 13})
         response = client.post('/purchasePlaces', data=club2)
         soup = BeautifulSoup(response.data, "html.parser")
         assert "You can't book more than 12 places" == soup.li.text
 
     def test_should_refuse_more_12_total(self, client, club2):
+        '''
+        test to book more than 12 places in a two-part reservation
+        '''
         club2.update({"places": 1})
         response = client.post('/purchasePlaces', data=club2)
         soup = BeautifulSoup(response.data, "html.parser")
@@ -44,13 +57,23 @@ class TestPlaces:
 
         
 class TestDate:
+    '''
+    test the booking for the past competitions 
+    '''
 
     def test_should_not_display_book_link_for_past_competitions(self, connect):
+        '''
+        test that the booking link isn't displayed when competition date is older than today
+        '''
         li = connect.find_all("li")
         assert not li[0].a
         assert li[1].a
 
     def test_forged_url_on_past_competition_should_raise_flash(self, client):
+        '''
+        test that a flash warning occur when trying to connect to an URL on an old competition
+        '''
         url = '/book/Spring Festival/Iron Temple'
         response = client.get(url)
         assert "You cannot book for a past competition" in response.data.decode()
+

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,0 +1,13 @@
+
+class TestPointsUpdate:
+
+    def test_should_not_be_ok_the_second_time(self, connect, client, club2):
+        '''
+        this books an amount of points-1 places
+        then test if 1 points remains displayed on page
+        '''
+        points = int(connect.span.text)
+        club2.update({"places": points-1})
+        response = client.post('/purchasePlaces', data=club2)
+        assert f"Great ! {points-1} places booked for {club2['competition']}" in response.data.decode()
+        print(int(connect.span.text))

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -10,4 +10,3 @@ class TestPointsUpdate:
         club2.update({"places": points-1})
         response = client.post('/purchasePlaces', data=club2)
         assert f"Great ! {points-1} places booked for {club2['competition']}" in response.data.decode()
-        print(int(connect.span.text))


### PR DESCRIPTION
```
=============================================== test session starts ===============================================
platform linux -- Python 3.11.0rc1, pytest-8.4.1, pluggy-1.6.0 -- /home/b/.local/share/virtualenvs/prod11-Eg1GQr7z/bin/python
cachedir: .pytest_cache
rootdir: /home/b/Documents/OCR/projet11/prod11
plugins: cov-6.2.1, flask-1.3.0
collected 10 items                                                                                                

tests/test_connection.py::test_should_status_code_ok PASSED
tests/test_connection.py::test_should_display_sorry_with_unknown_email PASSED
tests/test_connection.py::test_shoul_display_page_on_known_email PASSED
tests/test_purchase.py::TestPoints::test_should_nok_when_too_much_points PASSED
tests/test_purchase.py::TestPoints::test_should_ok_when_enough_points PASSED
tests/test_purchase.py::TestPlaces::test_should_refuse_more_12_once PASSED
tests/test_purchase.py::TestPlaces::test_should_refuse_more_12_total PASSED
tests/test_purchase.py::TestDate::test_should_not_display_book_link_for_past_competitions PASSED
tests/test_purchase.py::TestDate::test_forged_url_on_past_competition_should_raise_flash PASSED
tests/test_update.py::TestPointsUpdate::test_should_not_be_ok_the_second_time PASSED

================================================= tests coverage ==================================================
_______________________________ coverage: platform linux, python 3.11.0-candidate-1 _______________________________

Name        Stmts   Miss  Cover
-------------------------------
server.py      62      4    94%
-------------------------------
TOTAL          62      4    94%
=============================================== 10 passed in 0.29s ================================================

```